### PR TITLE
[feat] Add Support for interrupting playlist

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -6,7 +6,8 @@
                 "IPAddress",
                 "Port",
                 "Frequency",
-                "IdleAction"
+                "IdleAction",
+                "PauseablePlaylist"
             ]   
         },
         "PixelRadioRDSSettings": {
@@ -60,6 +61,17 @@
                 "Mute": 1,
                 "Disable Carrier": 2
             }
+        },
+        "PauseablePlaylist": {
+            "name": "PauseablePlaylist",
+            "description": "Pauseable Playlist",
+            "tip": "Ignore the set Playlist Idle Behavior on the given playlist name",
+            "restart": 1,
+            "reboot": 0,
+            "type": "text",
+            "default": "",
+            "size": 30,
+            "maxlength": 150
         },
         "Frequency": {
             "name": "Frequency",

--- a/src/FPPPixelRadio.cpp
+++ b/src/FPPPixelRadio.cpp
@@ -304,6 +304,13 @@ public:
         int track = mediaDetails.track;
         int length = mediaDetails.length;
         
+        if( playlist["name"].asString().compare(currentPlaylist) != 0 ) {
+            LogDebug(VB_PLUGIN, "Setting currentplaylist to %s because it's currently %s\n", playlist["name"].asString().c_str(), currentPlaylist.c_str());
+            currentPlaylist = playlist["name"].asString();
+            
+        }
+
+
         std::string type = playlist["currentEntry"]["type"].asString();
         if (type != "both" && type != "media") {
             title = "";

--- a/src/FPPPixelRadio.cpp
+++ b/src/FPPPixelRadio.cpp
@@ -30,6 +30,9 @@ public:
 
 class FPPPixelRadioPlugin : public FPPPlugin {
 public:
+    std::string lastPlayedPlaylist = "";
+    std::string currentPlaylist = "";
+    
     std::string baseURL;
 
     
@@ -279,12 +282,20 @@ public:
             nextRDSTime = 0;
             nextStationTime = 0;
         }
+
+        bool doStopActions = currentPlaylist.compare(settings["PauseablePlaylist"]) == 0 ||
+            ( lastPlayedPlaylist.compare("") == 0 || 
+            lastPlayedPlaylist.compare(settings["PauseablePlaylist"]) != 0);
+
         if (action == "start") {
+            currentPlaylist = incomingPlaylist;  
             startAction();
         } else if (action == "stop") {
-            stopAction();
+            lastPlayedPlaylist = currentPlaylist;
+            if( doStopActions ) {
+                stopAction();
+            }
         }
-        
     }
     virtual void mediaCallback(const Json::Value &playlist, const MediaDetails &mediaDetails) {
         std::string title = mediaDetails.title;
@@ -314,6 +325,7 @@ public:
         setIfNotFound("IdleAction", "0");
         setIfNotFound("IPAddress", "");
         setIfNotFound("Port", "8080");
+        setIfNotFound("PauseablePlaylist", "", true);
 
         setIfNotFound("StationID", "Merry   Christ- mas", true);        
         setIfNotFound("RDS", "[{Artist} - {Title}]", true);

--- a/src/FPPPixelRadio.cpp
+++ b/src/FPPPixelRadio.cpp
@@ -288,7 +288,7 @@ public:
             lastPlayedPlaylist.compare(settings["PauseablePlaylist"]) != 0);
 
         if (action == "start") {
-            currentPlaylist = incomingPlaylist;  
+            currentPlaylist = playlist["name"].asString();  
             startAction();
         } else if (action == "stop") {
             lastPlayedPlaylist = currentPlaylist;


### PR DESCRIPTION
Addresses https://github.com/FalconChristmas/fpp-PixelRadio/issues/2

Another plugin, such as Remote Falcon, will pause a playlist for another playlist. FPP does not send a signal on pausing/resuming a playlist. FPP also doesn't send any details about the "stopped" playlist. This would cause the "Playlist Idle Behavior" to be triggered on an interrupt, but not able to restore on a 'resume' because no signal is sent out. Therefore a resumed playlist would be in the idle behavior.

This feature allows you to define a 'main' playlist, which changes whether or not the idle behavior would be triggered. This now allows for resume to occur on that one 'main' playlist.

In the future, this could be a set of playlists, but my JS is not savvy enough to design a UI for a combo box, and one playlist should be enough for this.
